### PR TITLE
critical sections book page: each task gets its own context

### DIFF
--- a/book/en/src/internals/critical-sections.md
+++ b/book/en/src/internals/critical-sections.md
@@ -50,7 +50,7 @@ const APP: () = {
     }
 
     #[interrupt(binds = UART1, priority = 2, resources = [x])]
-    fn bar(c: foo::Context) {
+    fn bar(c: bar::Context) {
         let mut x: &mut u64 = c.resources.x;
 
         *x += 1;


### PR DESCRIPTION
Fixing what was probably a copy-paste error; different tasks each have different types for their context argument.